### PR TITLE
Fix reference to Main.fsproj in Test.fsproj

### DIFF
--- a/test/Test.fsproj
+++ b/test/Test.fsproj
@@ -15,7 +15,7 @@
    !-->
   <ItemGroup>
     <Reference Include="../node_modules/fable-core/Fable.Core.dll" />
-    <ProjectReference Include="../Main.fsproj" />
+    <ProjectReference Include="../src/Main.fsproj" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
As is the project will build, presumably because the fable builder doesn't care about references, but this reference is to the wrong path. Because of that syntax highlighting in ionide (and presumably other projects) fails hard.

Almost forgot hat tip to @Banashek as he actually found the issue.