### PR TITLE
Getting started setup.py script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /npm-debug.log
 /yarn-error.log
+.DS_Store

--- a/GettingStarted.sln
+++ b/GettingStarted.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Main", "src\Main.fsproj", "{968747A0-B0E6-4612-808B-89EDEC1DEFB8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{968747A0-B0E6-4612-808B-89EDEC1DEFB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{968747A0-B0E6-4612-808B-89EDEC1DEFB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{968747A0-B0E6-4612-808B-89EDEC1DEFB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{968747A0-B0E6-4612-808B-89EDEC1DEFB8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -74,15 +74,6 @@ the correct version of [Fable](http://fable.io/).
 Now that the project is successfully downloaded and installed, you need to
 customize it so that it becomes **your** project:
 
-* You will need to change the `ProjectGuid` in the `src/Main.fsproj` and
-  `test/Test.fsproj` files.
-
-  You cannot use the existing GUIDs. You can create a new GUID by using
-  [this site](https://guidgenerator.com/).
-
-  Every `.fsproj` file must have a different GUID. The GUID must be upper-case,
-  and it must be wrapped in `{}`
-
 * You will need to change these properties in the
   [`package.json`](https://yarnpkg.com/en/docs/package-json) file:
 

--- a/setup.py
+++ b/setup.py
@@ -4,27 +4,18 @@ from subprocess import check_call, check_output
 import json
 import shutil
 
-check_call('brew install npm', shell=True)
 check_call('brew install yarn', shell=True)
-check_call('npm install --global yarn', shell=True)
 check_call('yarn install', shell=True)
-
-# update GUID
-new_guid = check_output('uuidgen').strip()
-with open('src/Main.fsproj') as f:
-    fsproj = f.read()
-with open('src/Main.fsproj', 'w') as f:
-    f.write(fsproj.replace('4057826A-1B4A-4553-832E-9570A3394346', new_guid))
 
 package = json.loads(open('package.json').read())
 package['name'] = raw_input('Project name: ')
 package['description'] = raw_input('Project description: ')
 package['repository'] = raw_input('Project repository: ')
 with open('package.json', 'w') as f: 
-    f.write(json.dumps(package, indent=4))
+    f.write(json.dumps(package, indent=2))
     
 
 shutil.move('GettingStarted.sln', package['name'] + '.sln')
 
-print 'Done! Now use "yarn" or "yarn watch" to compile.'
-print 'The output file is in dist/index.html'
+print 'Done! The project is now built. Use "yarn watch" to live compile as you save.'
+print 'You can open dist/index.html in your browser to run your code'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 from subprocess import check_call, check_output
 import json
@@ -17,5 +18,7 @@ with open('package.json', 'w') as f:
 
 shutil.move('GettingStarted.sln', package['name'] + '.sln')
 
-print 'Done! The project is now built. Use "yarn watch" to live compile as you save.'
-print 'You can open dist/index.html in your browser to run your code'
+print('Done! The project is now built.')
+print('You can open dist/index.html in your browser to run your code.')
+print('You can use "yarn" to recompile.')
+print('You can use "yarn watch" to automatically recompile when you save.')

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from subprocess import check_call, check_output
+import json
+import shutil
+
+check_call('brew install npm', shell=True)
+check_call('brew install yarn', shell=True)
+check_call('npm install --global yarn', shell=True)
+check_call('yarn install', shell=True)
+
+# update GUID
+new_guid = check_output('uuidgen').strip()
+with open('src/Main.fsproj') as f:
+    fsproj = f.read()
+with open('src/Main.fsproj', 'w') as f:
+    f.write(fsproj.replace('4057826A-1B4A-4553-832E-9570A3394346', new_guid))
+
+package = json.loads(open('package.json').read())
+package['name'] = raw_input('Project name: ')
+package['description'] = raw_input('Project description: ')
+package['repository'] = raw_input('Project repository: ')
+with open('package.json', 'w') as f: 
+    f.write(json.dumps(package, indent=4))
+    
+
+shutil.move('GettingStarted.sln', package['name'] + '.sln')
+
+print 'Done! Now use "yarn" or "yarn watch" to compile.'
+print 'The output file is in dist/index.html'

--- a/src/Main.fsproj
+++ b/src/Main.fsproj
@@ -14,8 +14,12 @@
    !  They must start with ./ or ../ so Fable knows that they're relative paths.
    !-->
   <ItemGroup>
-    <Reference Include="../node_modules/fable-core/Fable.Core.dll" />
-    <Reference Include="../node_modules/fable-powerpack/Fable.PowerPack.dll" />
+    <Reference Include="Fable.Core">
+      <HintPath>..\node_modules\fable-core\Fable.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Fable.PowerPack">
+      <HintPath>..\node_modules\fable-powerpack\Fable.PowerPack.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <!--
@@ -47,6 +51,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="js\Message.js" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Choose>

--- a/test/Test.fsproj
+++ b/test/Test.fsproj
@@ -14,7 +14,8 @@
    !  They must start with ./ or ../ so Fable knows that they're relative paths.
    !-->
   <ItemGroup>
-    <Reference Include="../node_modules/fable-core/Fable.Core.dll" />
+    <Reference Include="Fable.Core">
+        <HintPath>..\node_modules\fable-core\Fable.Core.dll</HintPath>
     <ProjectReference Include="../src/Main.fsproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Also improves experience under Visual Studio (for Mac at least).

This is a bit of a rough draft obviously. The `setup.py` file only works for macOS because it assumes homebrew exists, and python isn't even installed by default on windows so that's a problem. 

But I think something like this, but built out to support apt-get/yum/whatever and windows would be a lot nicer when getting started.

I'd love to get your feedback on this.